### PR TITLE
small fix to allow CMakeLists to find python versions with minor vers…

### DIFF
--- a/buckettools/CMakeLists.txt
+++ b/buckettools/CMakeLists.txt
@@ -78,7 +78,7 @@ if (PYTHONINTERP_FOUND)
 
   # Get Python version from interpreter (find_package sets this but only for cmake >= 2.8.5, which we don't require)
   execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c
-                           "import sys; sys.stdout.write(sys.version[:5])"
+                           "import sys; sys.stdout.write(sys.version[:6].strip())"
                   OUTPUT_VARIABLE _PYTHON_VERSION_STR
                   RESULT_VARIABLE _PYTHON_VERSION_RESULT)
 

--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -92,7 +92,7 @@ if (PYTHONINTERP_FOUND)
 
   # Get Python version from interpreter (find_package sets this but only for cmake >= 2.8.5, which we don't require)
   execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c
-                           "import sys; sys.stdout.write(sys.version[:5])"
+                           "import sys; sys.stdout.write(sys.version[:6].strip())"
                   OUTPUT_VARIABLE _PYTHON_VERSION_STR
                   RESULT_VARIABLE _PYTHON_VERSION_RESULT)
 


### PR DESCRIPTION
…ions >=10.

Previously had hardwired sys.version[:5] which truncated python versions 2.7.10 to 2.7.1 and broke the builds.  This fix should work for both 1 and 2 digit minor versions without leaving trailing white spaces.
