### PR TITLE
minor python3 fixes to updateshml and updatetfml

### DIFF
--- a/buckettools/scripts/updateshml
+++ b/buckettools/scripts/updateshml
@@ -73,7 +73,7 @@ for f in args.file:
 def update_string_value(path):
   global changed
   elements = tree.findall(path)
-  if len(elements) is not 0:
+  if len(elements) !=  0:
     for element in elements:
       if element.find("string_value") is None:
         text = element.text
@@ -160,8 +160,8 @@ def update_python3():
       with tempfile.NamedTemporaryFile(mode='w', buffering=1, suffix='.py') as tf:
         # write code string to file and add a linesep to clear buffer
         tf.file.write(element.text+os.linesep)
-        # try calling 2to3 (NOTE assuming 2to3-2.7 is valid here across platforms!)
-        command = ["2to3-2.7", "-W", "-n", "--add-suffix=3", "-o", os.path.dirname(tf.name), tf.name]
+        # try calling 2to3 (NOTE assuming 2to3  is valid here across platforms!)
+        command = ["2to3", "-W", "-n", "--add-suffix=3", "-o", os.path.dirname(tf.name), tf.name]
         try:
           p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         except Exception as exc:

--- a/buckettools/scripts/updatetfml
+++ b/buckettools/scripts/updatetfml
@@ -227,8 +227,8 @@ def update_python3():
       with tempfile.NamedTemporaryFile(mode='w', buffering=1, suffix='.py') as tf:
         # write code string to file and add a linesep to clear buffer
         tf.file.write(element.text+os.linesep)
-        # try calling 2to3 (NOTE assuming 2to3-2.7 is valid here across platforms!)
-        command = ["2to3-2.7", "-W", "-n", "--add-suffix=3", "-o", os.path.dirname(tf.name), tf.name]
+        # try calling 2to3 (NOTE assuming 2to3 is valid here across platforms!)
+        command = ["2to3", "-W", "-n", "--add-suffix=3", "-o", os.path.dirname(tf.name), tf.name]
         try:
           p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         except Exception as exc:


### PR DESCRIPTION
minor fixes to updateshml and updatetfml for building in 20.04 python3 environment (tested in 20.04 docker container)

*changed 2to3-2.7 to generic 2.3 command
* fixed syntax error updateshml
